### PR TITLE
Empty line convention for multi-line blocks changed.

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -37,7 +37,7 @@ Formatting
   [Example][dot guideline example].
 * Use 2 space indentation (no tabs).
 * Use an empty line between methods.
-* Use empty lines around multi-line blocks.
+* Use an empty line between multi-line blocks.
 * Use spaces around operators, except for unary operators, such as `!`.
 * Use spaces after commas, after colons and semicolons, around `{` and before
   `}`.


### PR DESCRIPTION
I think what we want is:
```ruby
describe Core::Enum do
  context '#initialize' do
    it 'Return an enum instance for an existing constant' do
      expect(ExampleEnum::ONE.class.superclass).to be_a ExampleEnum.class
    end

    it 'Raise an error for an not existing constant' do
      expect { ExampleEnum::X }.to raise_error(ArgumentError, 'ENUM X not found')
    end
  end
end
```

But the convention says:
```ruby
describe Core::Enum do

  context '#initialize' do

    it 'Return an enum instance for an existing constant' do
      expect(ExampleEnum::ONE.class.superclass).to be_a ExampleEnum.class
    end

    it 'Raise an error for an not existing constant' do
      expect { ExampleEnum::X }.to raise_error(ArgumentError, 'ENUM X not found')
    end

  end

end
```