### PR TITLE
Set line length convention to 100 chars.

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -21,7 +21,7 @@ Formatting
 ----------
 
 * Avoid inline comments.
-* Break long lines after 80 characters.
+* Break long lines after 100 characters.
 * Delete trailing whitespace.
 * Don't include spaces after `(`, `[` or before `]`, `)`.
 * Don't misspell.

--- a/style/rubocop/.rubocop.yml
+++ b/style/rubocop/.rubocop.yml
@@ -130,7 +130,7 @@ LineEndConcatenation:
   Enabled: false
 
 LineLength:
-  Max: 80
+  Max: 100
 
 MethodLength:
   Enabled: false


### PR DESCRIPTION
Line breaks should be for semantic reasons less for style reasons. To short line
lengths destroys the semantic expressiveness and makes the code harder to read.

Why?
- The 80 chars per line convention comes from punched cards. Well, for
  historical reasons... Anyone still use punched cards?
- OK, there must be some other good reasons. The VT 100 DEC video terminal shows
  80 chars per line. Anyone still use this?
- More than 80 chars could not be printed on a A4 letter. Save the trees!

What limits the line length today?
- GitHubs file view is able to show ~125 chars without horizontal scrolling. The
  exact length depends from OS, browser, font type. 120 chars should be save.
  See http://stackoverflow.com/questions/22207920/what-is-githubs-character-limit-or-line-length-for-viewing-files-on-github
  Any reasons why GitHub doesn't use responsive design?
- Atom editor on screens with retina display (1920px) or external monitor
  (2560px) is able to show more than 120 chars per line. Even with visible tree
  view and line numbers. To show tree view and two horizontal split panels on
  retina display you have to decrease the font size from 16pt to 14pt to have
  still 100 chars per line visible.

So 100 chars per line should fit any reasonable use case. 20 chars more helps a
lot to keep the sources readable.

See: http://hilton.org.uk/blog/source-code-line-length