### PR TITLE
StringLiterals: EnforcedStyle: double_quotes

### DIFF
--- a/style/rubocop/.rubocop.yml
+++ b/style/rubocop/.rubocop.yml
@@ -201,7 +201,7 @@ SpecialGlobalVars:
   Enabled: false
 
 StringLiterals:
-  EnforcedStyle: single_quotes
+  EnforcedStyle: double_quotes
 
 VariableInterpolation:
   Enabled: false


### PR DESCRIPTION
Changes StringLiterals: EnforcedStyle: from single_quotes to double_quotes.
This is already the preferred way in our style guide:

> Prefer double quotes for strings.
https://github.com/webionate/guides/tree/master/style#ruby

The Article https://viget.com/extend/just-use-double-quoted-ruby-strings has a good explanation why:
> JUST USE DOUBLE-QUOTED STRINGS
>
> So if there's no meaningful performance difference between the two methods of Ruby string instantiation, shouldn't I just pick my favorite? Well, no. The absence of difference makes one better.

> Since there is no measurable performance advantage for either, any time (however marginal) spent thinking or talking about a choice between the two is wasted. When you prefer single quoted strings, you have to think when you need interpolation. When you use double quoted strings, you never have to think. (I'd also add, anecdotally, that apostrophes are more prevalent in strings than double quotes, which again means less thinking when using double-quoted strings.)
> 
> Therefore always using double-quoted strings results in the least possible wasted time and effort.